### PR TITLE
Add setuptools to the pip.extensions sls on Debian.

### DIFF
--- a/pip/map.jinja
+++ b/pip/map.jinja
@@ -4,6 +4,7 @@
         'dev_pkgs': [
           'build-essential',
           'python-dev',
+          'python-setuptools',
         ],
     },
     'RedHat': {


### PR DESCRIPTION
Nearly all packages that require python-dev also require python-setuptools, so install it along python-dev.

Signed-off-by: Rene Jochum <rene@jochums.at>